### PR TITLE
Fix typo in README for extension package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ channel to the Ledger Hardware Device.
 Below are examples and notes on installing the necessary transports:
 
 ```shell
-# Install the extension pacakge
+# Install the extension package
 /home/ricmoo> npm install @ethers-ext/signer-ledger
 
 # Depending on your environment, install any of the


### PR DESCRIPTION
Corrected a small typo in the install instructions: "pacakge" → "package".

This improves readability. No code changes included.